### PR TITLE
Rust: Add pr_*_ratelimited

### DIFF
--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -12,6 +12,7 @@
 #include <linux/platform_device.h>
 #include <linux/security.h>
 #include <asm/io.h>
+#include <linux/printk.h>
 
 __noreturn void rust_helper_BUG(void)
 {
@@ -277,6 +278,13 @@ void *rust_helper_dev_get_drvdata(struct device *dev)
 	return dev_get_drvdata(dev);
 }
 EXPORT_SYMBOL_GPL(rust_helper_dev_get_drvdata);
+
+void rust_helper_ratelimit_state_init(struct ratelimit_state *rs)
+{
+	static DEFINE_RATELIMIT_STATE(rs_tmpl, DEFAULT_RATELIMIT_INTERVAL, DEFAULT_RATELIMIT_BURST);
+	*rs = rs_tmpl;
+}
+EXPORT_SYMBOL_GPL(rust_helper_ratelimit_state_init);
 
 /* We use bindgen's --size_t-is-usize option to bind the C size_t type
  * as the Rust usize type, so we can use it in contexts where Rust

--- a/rust/kernel/prelude.rs
+++ b/rust/kernel/prelude.rs
@@ -19,7 +19,11 @@ pub use macros::{module, module_misc_device};
 
 pub use super::build_assert;
 
-pub use super::{dbg, pr_alert, pr_crit, pr_debug, pr_emerg, pr_err, pr_info, pr_notice, pr_warn};
+pub use super::{
+    dbg, pr_alert, pr_alert_ratelimited, pr_crit, pr_crit_ratelimited, pr_debug, pr_emerg,
+    pr_emerg_ratelimited, pr_err, pr_err_ratelimited, pr_info, pr_info_ratelimited, pr_notice,
+    pr_notice_ratelimited, pr_warn, pr_warn_ratelimited, printk_ratelimit,
+};
 
 pub use super::static_assert;
 

--- a/rust/kernel/print.rs
+++ b/rust/kernel/print.rs
@@ -12,6 +12,19 @@ use core::fmt;
 use crate::bindings;
 use crate::c_types::{c_char, c_void};
 
+pub use bindings::___ratelimit;
+pub use bindings::__printk_ratelimit;
+pub use bindings::ratelimit_state;
+
+#[doc(hidden)]
+extern "C" {
+    /// This function initializes ratelimit_state with DEFAULT_RATELIMIT_INTERVAL
+    /// and DEFAULT_RATELIMIT_BURST.
+    /// It should only be used inside [`print_macro_ratelimited`] macro.
+    #[allow(improper_ctypes)]
+    pub fn rust_helper_ratelimit_state_init(rs: *mut bindings::ratelimit_state);
+}
+
 // Called from `vsprintf` with format specifier `%pA`.
 #[no_mangle]
 unsafe fn rust_fmt_argument(buf: *mut c_char, end: *mut c_char, ptr: *const c_void) -> *mut c_char {
@@ -190,11 +203,104 @@ macro_rules! print_macro (
     );
 );
 
+/// Same as [`print_macro`], but ratelimites messages with local ratelimit_state.
+/// This emulates what [`printk_ratelimited`] macro does in C.
+///
+/// Public but hidden since it should only be used from public macros.
+///
+/// The extra parameter [`where`] is a string literal that will be used as an
+/// identifier when ratelimite is triggered. In C this is populated with
+/// __function__.
+#[doc(hidden)]
+#[cfg(not(testlib))]
+#[macro_export]
+macro_rules! print_macro_ratelimited (
+    // The non-continuation cases (most of them, e.g. `INFO`).
+    ($format_string:path, false, $where:literal, $($arg:tt)+) => ({
+        static mut PRINTK_RS: core::mem::MaybeUninit<$crate::print::ratelimit_state> =
+            core::mem::MaybeUninit::<$crate::print::ratelimit_state>::uninit();
+        static mut PRINTK_RS_PTR: core::sync::atomic::AtomicPtr<$crate::print::ratelimit_state> =
+            core::sync::atomic::AtomicPtr::<$crate::print::ratelimit_state>::new(core::ptr::null_mut());
+        static mut PRINTK_RS_AVAILABLE: core::sync::atomic::AtomicBool =
+            core::sync::atomic::AtomicBool::new(false);
+
+        // SAFETY: [`PRINTK_RS_AVAILABLE`] and [`PRINTK_RS_PTR`] is used to
+        // control the intialization of [`PRINTK_RS`] - a local
+        // [`ratelimit_state`] initialized with [`DEFAULT_RATELIMIT_INTERVAL`]
+        // and [`DEFAULT_RATELIMIT_BURST`]. All of these three variables are
+        // static local variables to avoid dynamic memory allocation and no
+        // lock is used because printk can be used in any circumstance.
+        //
+        // The hidden macro [`call_printk`] should only be called by the
+        // documented printing macros which ensure the format string is one of
+        // the fixed ones.
+        // All `__LOG_PREFIX`s are null-terminated as they are generated
+        // by the `module!` proc macro or fixed values defined in a kernel
+        // crate.
+        unsafe {
+            if PRINTK_RS_AVAILABLE.compare_exchange(
+                false,
+                true,
+                core::sync::atomic::Ordering::SeqCst,
+                core::sync::atomic::Ordering::SeqCst
+            ).is_ok() {
+                // Zero out [`PRINTK_RS`] then initialize it using
+                // [`rust_helper_ratelimit_state_init`] helper function.
+                *PRINTK_RS.as_mut_ptr() = $crate::print::ratelimit_state::default();
+                $crate::print::rust_helper_ratelimit_state_init(PRINTK_RS.as_mut_ptr());
+
+                // Make PRINTK_RS_PTR point at PRINTK_RS so later we can call
+                // [`___ratelimit`] with it.
+                if PRINTK_RS_PTR.load(
+                    core::sync::atomic::Ordering::SeqCst
+                ).is_null() {
+                    PRINTK_RS_PTR.store(
+                        PRINTK_RS.as_mut_ptr(),
+                        core::sync::atomic::Ordering::SeqCst
+                    );
+                }
+            }
+
+            // [`PRINTK_RS`] can be uninitialized under concurrent situation,
+            // if so, we print message without ratelimit control.
+            // Otherwise we call __ratelimit to decide if
+            // enforce ratelimit.
+            if PRINTK_RS_PTR.load(core::sync::atomic::Ordering::SeqCst).is_null() ||
+                $crate::print::___ratelimit(
+                    PRINTK_RS_PTR.load(core::sync::atomic::Ordering::SeqCst),
+                    $crate::c_str!($where).as_char_ptr()
+                ) != 0 {
+                $crate::print::call_printk(
+                    &$format_string,
+                    crate::__LOG_PREFIX,
+                    format_args!($($arg)+),
+                );
+            }
+        }
+    });
+
+    // The `CONT` case.
+    ($format_string:path, true, $where:literal, $($arg:tt)+) => ({
+        $crate::print::call_printk_cont(
+            format_args!($($arg)+),
+        );
+    });
+);
+
 /// Stub for doctests
 #[cfg(testlib)]
 #[macro_export]
 macro_rules! print_macro (
     ($format_string:path, $e:expr, $($arg:tt)+) => (
+        ()
+    );
+);
+
+/// Stub for doctests
+#[cfg(testlib)]
+#[macro_export]
+macro_rules! print_macro_ratelimited (
+    ($format_string:path, $e:expr, $where:literal, $($arg:tt)+) => (
         ()
     );
 );
@@ -233,6 +339,35 @@ macro_rules! pr_emerg (
     )
 );
 
+/// Prints an emergency-level message (level 0) with ratelimit.
+///
+/// Use this level if the system is unusable.
+///
+/// Equivalent to the kernel's [`pr_emerg_ratelimited`] macro.
+///
+/// Mimics the interface of [`std::print!`]. See [`core::fmt`] and
+/// [`alloc::format!`] for information about the formatting syntax.
+///
+/// [`pr_emerg`]: https://www.kernel.org/doc/html/latest/core-api/printk-basics.html#c.pr_emerg
+/// [`std::print!`]: https://doc.rust-lang.org/std/macro.print.html
+///
+/// [`where`] parameter is a string literal that will be used as an
+/// identifier when ratelimite is triggered. In C this is populated with
+/// __function__.
+///
+/// # Examples
+///
+/// ```
+/// # use kernel::prelude::*;
+/// pr_emerg_ratelimited!("myfunc", "hello {}\n", "there");
+/// ```
+#[macro_export]
+macro_rules! pr_emerg_ratelimited (
+    ($where:literal, $($arg:tt)*) => (
+        $crate::print_macro_ratelimited!($crate::print::format_strings::EMERG, false, $where, $($arg)*)
+    )
+);
+
 /// Prints an alert-level message (level 1).
 ///
 /// Use this level if action must be taken immediately.
@@ -255,6 +390,35 @@ macro_rules! pr_emerg (
 macro_rules! pr_alert (
     ($($arg:tt)*) => (
         $crate::print_macro!($crate::print::format_strings::ALERT, false, $($arg)*)
+    )
+);
+
+/// Prints an alert-level message (level 1) with ratelimit.
+///
+/// Use this level if action must be taken immediately.
+///
+/// Equivalent to the kernel's [`pr_alert_ratelimited`] macro.
+///
+/// Mimics the interface of [`std::print!`]. See [`core::fmt`] and
+/// [`alloc::format!`] for information about the formatting syntax.
+///
+/// [`pr_alert`]: https://www.kernel.org/doc/html/latest/core-api/printk-basics.html#c.pr_alert
+/// [`std::print!`]: https://doc.rust-lang.org/std/macro.print.html
+///
+/// [`where`] parameter is a string literal that will be used as an
+/// identifier when ratelimite is triggered. In C this is populated with
+/// __function__.
+///
+/// # Examples
+///
+/// ```
+/// # use kernel::prelude::*;
+/// pr_alert_ratelimited!("myfunc", "hello {}\n", "there");
+/// ```
+#[macro_export]
+macro_rules! pr_alert_ratelimited (
+    ($where:literal, $($arg:tt)*) => (
+        $crate::print_macro_ratelimited!($crate::print::format_strings::ALERT, false, $where, $($arg)*)
     )
 );
 
@@ -283,6 +447,35 @@ macro_rules! pr_crit (
     )
 );
 
+/// Prints a critical-level message (level 2) with ratelimit.
+///
+/// Use this level for critical conditions.
+///
+/// Equivalent to the kernel's [`pr_crit_ratelimited`] macro.
+///
+/// Mimics the interface of [`std::print!`]. See [`core::fmt`] and
+/// [`alloc::format!`] for information about the formatting syntax.
+///
+/// [`pr_crit`]: https://www.kernel.org/doc/html/latest/core-api/printk-basics.html#c.pr_crit
+/// [`std::print!`]: https://doc.rust-lang.org/std/macro.print.html
+///
+/// [`where`] parameter is a string literal that will be used as an
+/// identifier when ratelimite is triggered. In C this is populated with
+/// __function__.
+///
+/// # Examples
+///
+/// ```
+/// # use kernel::prelude::*;
+/// pr_crit_ratelimited!("myfunc", "hello {}\n", "there");
+/// ```
+#[macro_export]
+macro_rules! pr_crit_ratelimited (
+    ($where:literal, $($arg:tt)*) => (
+        $crate::print_macro_ratelimited!($crate::print::format_strings::CRIT, false, $where, $($arg)*)
+    )
+);
+
 /// Prints an error-level message (level 3).
 ///
 /// Use this level for error conditions.
@@ -305,6 +498,35 @@ macro_rules! pr_crit (
 macro_rules! pr_err (
     ($($arg:tt)*) => (
         $crate::print_macro!($crate::print::format_strings::ERR, false, $($arg)*)
+    )
+);
+
+/// Prints an error-level message (level 3) with ratelimit with ratelimit.
+///
+/// Use this level for error conditions.
+///
+/// Equivalent to the kernel's [`pr_err_ratelimited`] macro.
+///
+/// Mimics the interface of [`std::print!`]. See [`core::fmt`] and
+/// [`alloc::format!`] for information about the formatting syntax.
+///
+/// [`pr_err`]: https://www.kernel.org/doc/html/latest/core-api/printk-basics.html#c.pr_err
+/// [`std::print!`]: https://doc.rust-lang.org/std/macro.print.html
+///
+/// [`where`] parameter is a string literal that will be used as an
+/// identifier when ratelimite is triggered. In C this is populated with
+/// __function__.
+///
+/// # Examples
+///
+/// ```
+/// # use kernel::prelude::*;
+/// pr_err_ratelimited!("myfunc", "hello {}\n", "there");
+/// ```
+#[macro_export]
+macro_rules! pr_err_ratelimited (
+    ($where:literal, $($arg:tt)*) => (
+        $crate::print_macro_ratelimited!($crate::print::format_strings::ERR, false, $where, $($arg)*)
     )
 );
 
@@ -333,6 +555,35 @@ macro_rules! pr_warn (
     )
 );
 
+/// Prints a warning-level message (level 4) with ratelimit.
+///
+/// Use this level for warning conditions.
+///
+/// Equivalent to the kernel's [`pr_warn_ratelimited`] macro.
+///
+/// Mimics the interface of [`std::print!`]. See [`core::fmt`] and
+/// [`alloc::format!`] for information about the formatting syntax.
+///
+/// [`pr_warn`]: https://www.kernel.org/doc/html/latest/core-api/printk-basics.html#c.pr_warn
+/// [`std::print!`]: https://doc.rust-lang.org/std/macro.print.html
+///
+/// [`where`] parameter is a string literal that will be used as an
+/// identifier when ratelimite is triggered. In C this is populated with
+/// __function__.
+///
+/// # Examples
+///
+/// ```
+/// # use kernel::prelude::*;
+/// pr_warn_ratelimited!("myfunc", "hello {}\n", "there");
+/// ```
+#[macro_export]
+macro_rules! pr_warn_ratelimited (
+    ($where:literal, $($arg:tt)*) => (
+        $crate::print_macro_ratelimited!($crate::print::format_strings::WARNING, false, $where, $($arg)*)
+    )
+);
+
 /// Prints a notice-level message (level 5).
 ///
 /// Use this level for normal but significant conditions.
@@ -355,6 +606,35 @@ macro_rules! pr_warn (
 macro_rules! pr_notice (
     ($($arg:tt)*) => (
         $crate::print_macro!($crate::print::format_strings::NOTICE, false, $($arg)*)
+    )
+);
+
+/// Prints a notice-level message (level 5) with ratelimit.
+///
+/// Use this level for normal but significant conditions.
+///
+/// Equivalent to the kernel's [`pr_notice_ratelimited`] macro.
+///
+/// Mimics the interface of [`std::print!`]. See [`core::fmt`] and
+/// [`alloc::format!`] for information about the formatting syntax.
+///
+/// [`pr_notice`]: https://www.kernel.org/doc/html/latest/core-api/printk-basics.html#c.pr_notice
+/// [`std::print!`]: https://doc.rust-lang.org/std/macro.print.html
+///
+/// [`where`] parameter is a string literal that will be used as an
+/// identifier when ratelimite is triggered. In C this is populated with
+/// __function__.
+///
+/// # Examples
+///
+/// ```
+/// # use kernel::prelude::*;
+/// pr_notice_ratelimited!("myfunc", "hello {}\n", "there");
+/// ```
+#[macro_export]
+macro_rules! pr_notice_ratelimited (
+    ($where:literal, $($arg:tt)*) => (
+        $crate::print_macro_ratelimited!($crate::print::format_strings::NOTICE, false, $where, $($arg)*)
     )
 );
 
@@ -381,6 +661,35 @@ macro_rules! pr_notice (
 macro_rules! pr_info (
     ($($arg:tt)*) => (
         $crate::print_macro!($crate::print::format_strings::INFO, false, $($arg)*)
+    )
+);
+
+/// Prints an info-level message (level 6) with ratelimit.
+///
+/// Use this level for informational messages.
+///
+/// Equivalent to the kernel's [`pr_info_ratelimited`] macro.
+///
+/// Mimics the interface of [`std::print!`]. See [`core::fmt`] and
+/// [`alloc::format!`] for information about the formatting syntax.
+///
+/// [`pr_info`]: https://www.kernel.org/doc/html/latest/core-api/printk-basics.html#c.pr_info
+/// [`std::print!`]: https://doc.rust-lang.org/std/macro.print.html
+///
+/// [`where`] parameter is a string literal that will be used as an
+/// identifier when ratelimite is triggered. In C this is populated with
+/// __function__.
+///
+/// # Examples
+///
+/// ```
+/// # use kernel::prelude::*;
+/// pr_info_ratelimited!("myfunc", "hello {}\n", "there");
+/// ```
+#[macro_export]
+macro_rules! pr_info_ratelimited (
+    ($where:literal, $($arg:tt)*) => (
+        $crate::print_macro_ratelimited!($crate::print::format_strings::INFO, false, $where, $($arg)*)
     )
 );
 
@@ -438,4 +747,44 @@ macro_rules! pr_cont (
     ($($arg:tt)*) => (
         $crate::print_macro!($crate::print::format_strings::CONT, true, $($arg)*)
     )
+);
+
+/// Printk ratelimit control with a shared [`ratelimit_state`]. The state will be
+/// shared with all this macro & kernel's [`printk_ratelimit`] callers.
+///
+/// Equivalent to the kernel's [`printk_ratelimit`] function.
+///
+/// Returns `true` if ratelimit control is enforced, otherwise `false`.
+///
+/// [`where`] parameter is a string literal that will be used as an
+/// identifier when ratelimite is triggered. In C this is populated with
+/// __function__.
+///
+/// # Examples
+///
+/// ```
+/// # use kernel::prelude::*;
+/// # use kernel::pr_cont;
+///
+/// if printk_ratelimit!("myfunc") {
+///     pr_info!("hello");
+///     pr_cont!(" {}\n", "there");
+/// }
+/// ```
+#[cfg(not(testlib))]
+#[macro_export]
+macro_rules! printk_ratelimit (
+    ($where:literal) => (
+        // SAFETY: In any case the parameter should be a null-terminated string.
+        unsafe { $crate::print::__printk_ratelimit($crate::c_str!($where).as_char_ptr()) } != 0
+    )
+);
+
+/// Stub for doctests
+#[cfg(testlib)]
+#[macro_export]
+macro_rules! printk_ratelimit (
+    ($where:literal) => (
+        true
+    );
 );

--- a/samples/rust/rust_print.rs
+++ b/samples/rust/rust_print.rs
@@ -46,6 +46,20 @@ impl KernelModule for RustPrint {
         pr_cont!(" is {}", "continued");
         pr_cont!(" with {}\n", "args");
 
+        for i in 0..100 {
+            pr_emerg_ratelimited!("RustPrint::init", "Repetitive Emergency message {}", i);
+            pr_alert_ratelimited!("RustPrint::init", "Repetitive Alert message {}", i);
+            pr_crit_ratelimited!("RustPrint::init", "Repetitive Critical message {}", i);
+            pr_err_ratelimited!("RustPrint::init", "Repetitive Error message {}", i);
+            pr_warn_ratelimited!("RustPrint::init", "Repetitive Warning message {}", i);
+            pr_notice_ratelimited!("RustPrint::init", "Repetitive Notice message {}", i);
+            pr_info_ratelimited!("RustPrint::init", "Repetitive Info message {}", i);
+
+            if printk_ratelimit!("RustPrint::init") {
+                pr_warn!("Inside printk_ratelimit {}", i);
+            }
+        }
+
         Ok(RustPrint)
     }
 }


### PR DESCRIPTION
This commit adds equivalent pr_*_ratelimited to kernel crate.
They are macros that define a static local `ratelimit_state` and
uses Atomic and CAS to guard its initialization.
That `ratelimit_state` will be used later
by `___ratelimit()` to decide if to suppress the `printk` or not.

Because we use Atomic & CAS to help initialize `ratelimit_state`,
in concurrent situation some thread may reach `__ratelimit()`
before `ratelimit_state` is initialized. If that happens, we
call `printk` anyway.

This commit does not implement pr_debug_ratelimited since it's
special and way more complicated and deserves another dedicated
commit.

`printk_ratelimit` is also implemented in this commit

Signed-off-by: Fox Chen <foxhlchen@gmail.com>